### PR TITLE
fixes to save individual models with expected names

### DIFF
--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -99,6 +99,7 @@ class Spec3Pipeline(Pipeline):
         self.spectral_leak.save_results = self.save_results
         self.pixel_replace.suffix = 'pixel_replace'
         self.pixel_replace.save_results = self.save_results
+        self.pixel_replace.output_use_model = True
 
         # Retrieve the inputs:
         # could either be done via LoadAsAssociation and then manually

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from functools import partial
 
 from ..stpipe import Step
 from .. import datamodels
@@ -89,7 +90,7 @@ class PixelReplaceStep(Step):
                 # Setup output path naming if associations are involved.
                 asn_id = None
                 try:
-                    asn_id = self.input_model.meta.asn_table.asn_id
+                    asn_id = input_model.meta.asn_table.asn_id
                 except (AttributeError, KeyError):
                     pass
                 if asn_id is None:
@@ -134,11 +135,6 @@ class PixelReplaceStep(Step):
                         replacement = PixelReplacement(model, **pars)
                         replacement.replace()
                         self.record_step_status(replacement.output, 'pixel_replace', success=True)
-                        model = replacement.output
-                        output_path_name = self.make_output_path(basepath=model.meta.filename, suffix='pixel_replace')
-                        if self.save_results:
-                            model.meta.filename = output_path_name
-                            print(output_path_name)
 
                 return output_model
             #________________________________________


### PR DESCRIPTION
Well, the outlierdetectionstep was doing some funny business, actually in the resamplestep that it calls.

Regardless, this PR sets up things in the correct way, I believe. The changes are as follows:

First, in PixelReplaceStep, there were just a couple of bugs that prevented the make_output_name utility from being defined. 

Next, again in PixelReplaceStep, there is no need to explicitly call the make_output_name functionality.

The changes above are done in keeping with the philosophy that the steps themselves should take as little special action as possible, leaving any of the major configurations to the user/pipeline that is calling the step.

Leading to the final change in Spec3Pipeline itself, which is setting the parameter output_use_model. This tells the stpipe infrastructure to use the meta.filename in each of the models of the ModelContainer. OutlierDetectionStep should be doing the same thing, but it is taking a more complicated route, for some reason.

If you really want PixelReplaceStep to behave the same as if it were run from Spec3Pipeline, just add the setting for output_use_model and suffix in the spec definition for PixelReplaceStep.
